### PR TITLE
細かい不具合修正と調整

### DIFF
--- a/electron-main.ts
+++ b/electron-main.ts
@@ -139,6 +139,10 @@ function initWindowMenu() {
           label: "貼り付け",
           role: "paste"
         },
+        {
+          label: "削除",
+          role: "delete"
+        },
         { type: "separator" },
         {
           label: "ノートを上に移動",
@@ -288,7 +292,7 @@ function initWindowMenu() {
           }
         }
       ]
-    },
+    }
   ];
 
   const menu = Menu.buildFromTemplate(template as any);

--- a/src/containers/Pixi.tsx
+++ b/src/containers/Pixi.tsx
@@ -643,9 +643,8 @@ export default class Pixi extends InjectedComponent {
 
     // その他オブジェクト選択/削除
     if (
-      (setting.editMode === EditMode.Select ||
-        setting.editMode === EditMode.Delete) &&
-      setting.editObjectCategory === ObjectCategory.Other
+      setting.editMode === EditMode.Select ||
+      setting.editMode === EditMode.Delete
     ) {
       for (const object of chart.timeline.otherObjects) {
         const bounds = OtherObjectRenderer.getBounds(

--- a/src/containers/Pixi.tsx
+++ b/src/containers/Pixi.tsx
@@ -633,7 +633,7 @@ export default class Pixi extends InjectedComponent {
 
     // 選択中表示
     for (const object of editor.inspectorTargets) {
-      object.drawBounds(graphics, theme.selected);
+      object.drawBounds?.(graphics, theme.selected);
     }
 
     // 接続モードじゃないかノート外をタップしたら接続対象ノートを解除

--- a/src/stores/EditorSetting.ts
+++ b/src/stores/EditorSetting.ts
@@ -197,7 +197,10 @@ export default class EditorSetting {
     24,
     32,
     48,
-    64
+    64,
+    96,
+    128,
+    192
   ];
 
   /**

--- a/src/stores/EditorStore.ts
+++ b/src/stores/EditorStore.ts
@@ -470,6 +470,13 @@ export default class Editor {
     });
     Mousetrap.bind("mod+c", () => this.copy());
     Mousetrap.bind("mod+v", () => this.paste());
+    Mousetrap.bind(["del", "backspace"], () => {
+      const removeNotes = this.inspectorTargets.filter(
+        target => target instanceof NoteRecord
+      );
+      removeNotes.forEach(n => this.currentChart!.timeline.removeNote(n));
+      if (removeNotes.length > 0) this.currentChart!.save();
+    });
 
     ipcRenderer.on("moveDivision", (_: any, index: number) =>
       this.moveDivision(index)
@@ -512,7 +519,7 @@ export default class Editor {
       );
       location.reload();
     });
-    
+
     ipcRenderer.on("close", () => {
       for (let i = 0; i < this.charts.length; i++) this.saveConfirm(i);
       localStorage.setItem(

--- a/src/stores/EditorStore.ts
+++ b/src/stores/EditorStore.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer, remote } from "electron";
 import * as fs from "fs";
 import * as _ from "lodash";
-import { action, flow, observable } from "mobx";
+import { action, flow, observable, runInAction } from "mobx";
 import * as Mousetrap from "mousetrap";
 import { VariantType } from "notistack";
 import * as util from "util";
@@ -225,10 +225,12 @@ export default class Editor {
       properties: ["openFile", "createDirectory"]
     };
     dialog.showSaveDialog(window, options, (filePath: any) => {
-      if (filePath) {
-        this.currentChart!.filePath = filePath;
-        this.save();
-      }
+      runInAction(() => {
+        if (filePath) {
+          this.currentChart!.filePath = filePath;
+          this.save();
+        }
+      });
     });
   }
 


### PR DESCRIPTION
- 譜面が保存できない場合がある不具合を修正
  action ではないところで mobx のデータを操作していた
- 小節の最大分割数を 192 にした
- delete, backspace キーで選択中のノートを削除できるようにした
- BPM, 速度変更などのオブジェクトの選択条件を緩くした
  ツールバーで BPM などの項目を選択していないとオブジェクトを選択できないのは扱いづらかった
- 右クリックでノートを削除できるようにした