### PR TITLE
clean: Note と OtherObject を TimeLineObject 継承にした

### DIFF
--- a/src/objects/Note.ts
+++ b/src/objects/Note.ts
@@ -10,23 +10,14 @@ import { Mutable } from "../utils/mutable";
 import { Lane, LinePointInfo } from "./Lane";
 import LaneRendererResolver from "./LaneRendererResolver";
 import { Measure } from "./Measure";
+import TimelineObjectType from "./TimelineObject";
 
 interface INoteEditorProps {
   time: number;
 }
 
-export type NoteData = {
-  guid: GUID;
+export type NoteData = TimelineObjectType & {
   editorProps: INoteEditorProps;
-
-  /**
-   * 小節インデックス
-   */
-  measureIndex: number;
-  /**
-   * 小節内の位置
-   */
-  measurePosition: IFraction;
 
   horizontalSize: number;
   horizontalPosition: Fraction;

--- a/src/objects/OtherObject.ts
+++ b/src/objects/OtherObject.ts
@@ -6,20 +6,11 @@ import { OtherObjectType } from "../stores/MusicGameSystem";
 import { GUID } from "../utils/guid";
 import { Mutable } from "../utils/mutable";
 import { Measure } from "./Measure";
+import TimelineObjectType from "./TimelineObject";
 
-export type OtherObjectData = {
+export type OtherObjectData = TimelineObjectType & {
   type: number;
   value: number;
-  guid: GUID;
-
-  /**
-   * 小節インデックス
-   */
-  measureIndex: number;
-  /**
-   * 小節内の位置
-   */
-  measurePosition: Fraction;
 };
 
 const defaultOtherObjectData: OtherObjectData = {

--- a/src/objects/TimelineObject.ts
+++ b/src/objects/TimelineObject.ts
@@ -1,7 +1,13 @@
 import { Fraction } from "../math";
 import { GUID, guid } from "../utils/guid";
 
-export default class TimelineObject {
+export type TimelineObjectType = {
+  guid: GUID;
+  measureIndex: number;
+  measurePosition: Fraction;
+};
+
+export default class TimelineObject implements TimelineObjectType {
   guid: GUID = guid();
 
   /**


### PR DESCRIPTION
共通パラメータの定義を継承元に統一するため

## 解決したい問題
PJの譜面書き出し時に、 `measurePosition` を持つオブジェクトをforeachして `measurePosition.denominator` を同じ値に揃えたかったが、別個に定義されていて苦し紛れな共通化になっていた

```typescript
function adjustMeasurePosition(object: T & { measurePosition: Fraction }) {
  // do something
}

const adjustedNotes = notes.map(adjustMeasurePosition);
const adjustedObjects = chart.timeline.otherObjects.map(adjustMeasurePosition);
```
みたいな感じ

guidとか他の共通のパラメータも別個で定義されていたので、ついでに共通化

## 微妙なところ
最初単に `TimelineObject` を extends していこうと思ったが、 `TimelineObject` は class であるためPJ用の eventListener から参照できなかったため、Typeで `TimelineObject` を新たに定義した