### PR TITLE
NoteのcustomProps定義後、customPropsが無い時代の譜面を読み込んだ時にエラーになっていた

### DIFF
--- a/src/objects/Note.ts
+++ b/src/objects/Note.ts
@@ -184,7 +184,7 @@ export class NoteRecord extends Record<NoteData>(defaultNoteData) {
           inspectorConfig: noteType.customPropsInspectorConfig,
         };
         for (const prop of noteType.customProps) {
-          if (prop.key in data.customProps) {
+          if (data.customProps !== undefined && prop.key in data.customProps) {
             newProps[prop.key] = data.customProps[prop.key];
           } else if (
             typeof prop.defaultValue !== "string" ||


### PR DESCRIPTION
customPropsを定義していない場合、data.customPropsがundefinedになる。
customPropsが定義されているバージョンで、定義されていないバージョンの譜面を読み込むとdata.customPropsを参照するコードに到達し「Cannot use 'in' operator to search for 'x' in undefined」が出る。
data.customPropsのundefinedチェックを入れて対処。